### PR TITLE
Set Google Sheet id with env variable in gulp. Closes #4

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -15,6 +15,8 @@ var print = require('gulp-print');
 var underscore = require('underscore');
 var merge = require('merge-stream');
 var install = require("gulp-install");
+var env = require('gulp-env');
+var injectString = require('gulp-inject-string');
 
 var modules = ["datasets", "grid", "datatype", "methodology"];
 
@@ -56,10 +58,15 @@ gulp.task('buildDev', ['npm', 'bower', 'clean'], function() {
     gulp.src('./public/common/CNAME')
         .pipe(gulp.dest('out/'));
 
+    env.set({
+      GOOGLE_SHEET_KEY : '"1OhVbryeHBsPjJ3TjjVFlfM552pDKRjiUpTAXQJe9miA"'
+    });
+
     return merge(underscore.map(modules, function(module) {
         var target = gulp.src('./public/' + module + '/*.html');
 
         var customJs = gulp.src('./public/' + module + '/js/**.js')
+            .pipe(injectString.replace("//GOOGLE_SHEET_KEY", process.env.GOOGLE_SHEET_KEY))
             .pipe(gulp.dest('out/' + module + '/js'));
 
         var customCss = gulp.src('./public/' + module + '/css/**.css')

--- a/package.json
+++ b/package.json
@@ -14,7 +14,9 @@
   "dependencies": {
     "bower-files": "^3.7.0",
     "gulp-concat": "^2.5.2",
+    "gulp-env": "^0.4.0",
     "gulp-inject": "^1.2.0",
+    "gulp-inject-string": "^1.1.0",
     "gulp-install": "^0.4.0",
     "gulp-print": "^1.1.0",
     "gulp-uglify": "^1.2.0",

--- a/public/datasets/js/datasets.js
+++ b/public/datasets/js/datasets.js
@@ -25,7 +25,7 @@ var spinner = new Spinner(opts).spin(target);
 
  $(document).ready(function() {
      Tabletop.init({
-         key: "1OhVbryeHBsPjJ3TjjVFlfM552pDKRjiUpTAXQJe9miA",
+         key: //GOOGLE_SHEET_KEY, // Gulp will add the right key here
          callback: showInfo,
          parseNumbers: true
      });

--- a/public/datatype/js/datatype.js
+++ b/public/datatype/js/datatype.js
@@ -25,7 +25,7 @@ var spinner = new Spinner(opts).spin(target);
 
 $(document).ready(function() {
     Tabletop.init({
-        key: "1OhVbryeHBsPjJ3TjjVFlfM552pDKRjiUpTAXQJe9miA",
+        key: //GOOGLE_SHEET_KEY, // Gulp will add the right key here
         callback: showInfo,
         parseNumbers: true
     });

--- a/public/grid/js/grid.js
+++ b/public/grid/js/grid.js
@@ -26,7 +26,7 @@ var spinner = new Spinner(opts).spin(target);
  $(document).ready(function() {
 
      Tabletop.init({
-         key: "1OhVbryeHBsPjJ3TjjVFlfM552pDKRjiUpTAXQJe9miA",
+         key: //GOOGLE_SHEET_KEY, // Gulp will add the right key here
          callback: showInfo,
          parseNumbers: true
      });


### PR DESCRIPTION
While processing the custom js files, gulp will now also look for `//GOOGLE_SHEET_KEY` and replace it with whatever the env variable is set to.

I'm brand new to gulp, so want someone else to check my work. Is it okay to add new dependencies like this?

Closes #4 
